### PR TITLE
decimals get added to the values in the csv

### DIFF
--- a/scripts/csv_allocation.js
+++ b/scripts/csv_allocation.js
@@ -397,7 +397,7 @@ async function doAllocationRaw(beneficiary, tokens, transactionCount) {
 
   let poly =  new web3.eth.Contract(ABI, polyDistributionAddress);
 
-  var funcData = poly.methods.setAllocation(beneficiary,tokens,2).encodeABI();
+  var funcData = poly.methods.setAllocation(beneficiary,new BigNumber(tokens * (10 ** 18)),2).encodeABI();
   var rawTx = {
     nonce: web3.utils.toHex(transactionCount),
     gasLimit: web3.utils.toHex(200000),


### PR DESCRIPTION
The CSV file should only specify the amount of tokens we wish to allocate, the script will convert it by adding the 18 decimals.

So, if CSV file says 1, then 100000000000000000 (1 * 10 ** 18) tokens will actually be allocated.
